### PR TITLE
Expand factor model and report pipeline

### DIFF
--- a/src/buld_report.py
+++ b/src/buld_report.py
@@ -1,36 +1,200 @@
-import pathlib, pandas as pd
+import pathlib
+import sys
 from datetime import datetime
+
+import numpy as np
+import pandas as pd
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from src.utils_io import ROOT, PARQ, today_str
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.utils_io import ROOT, PARQ, load_yaml
+
+
+def _latest(prefix: str) -> pathlib.Path | None:
+    files = sorted(PARQ.glob(f"{prefix}_*.parquet"))
+    return files[-1] if files else None
+
+
+def _all(prefix: str) -> list[pathlib.Path]:
+    return sorted(PARQ.glob(f"{prefix}_*.parquet"))
+
+
+def _normalize_weights(tickers: list[str], weights_cfg: dict[str, float]) -> pd.Series:
+    if not tickers:
+        return pd.Series(dtype=float)
+    w = pd.Series(weights_cfg or {}, dtype=float)
+    w = w.reindex(tickers).fillna(0.0)
+    if w.sum() <= 0:
+        w = pd.Series(1.0 / len(tickers), index=tickers)
+    else:
+        w = w / w.sum()
+    return w
+
 
 def main():
-    # load latest parquet snapshots by prefix
-    def latest(prefix: str) -> pathlib.Path:
-        files = sorted((PARQ).glob(f"{prefix}_*.parquet"))
-        return files[-1] if files else None
+    watch = load_yaml(ROOT / "watchlist.yml")
+    tickers = watch.get("tickers", [])
+    notes = watch.get("notes", {})
+    weights = _normalize_weights(tickers, watch.get("weights", {}))
 
-    prices_p = latest("prices_daily")
-    fnds_p = latest("fundamentals_quarterly")
-    scores_p = latest("scores_daily")
+    scores_path = _latest("scores_daily")
+    fundamentals_path = _latest("fundamentals_quarterly")
+    prices_path = _latest("prices_daily")
 
-    scores = pd.read_parquet(scores_p) if scores_p else pd.DataFrame()
-    top10 = scores.head(10).round(3)
+    scores = pd.read_parquet(scores_path) if scores_path else pd.DataFrame()
+    fundamentals = pd.read_parquet(fundamentals_path) if fundamentals_path else pd.DataFrame()
+    prices = pd.read_parquet(prices_path) if prices_path else pd.DataFrame()
+
+    scores = scores[scores["ticker"].isin(tickers)] if not scores.empty else scores
+    fundamentals = fundamentals[fundamentals["ticker"].isin(tickers)] if not fundamentals.empty else fundamentals
+    prices = prices[prices["ticker"].isin(tickers)] if not prices.empty else prices
+
+    last_fundamental = pd.DataFrame()
+    if not fundamentals.empty:
+        fundamentals["fiscal_end"] = pd.to_datetime(fundamentals["fiscal_end"])
+        if "filed" in fundamentals.columns:
+            fundamentals["filed"] = pd.to_datetime(fundamentals["filed"])
+        last_fundamental = fundamentals.sort_values("fiscal_end").groupby("ticker").tail(1)
+
+    last_scores = scores.set_index("ticker") if not scores.empty else pd.DataFrame()
+    prior_scores = pd.DataFrame()
+    history_paths = _all("scores_daily")
+    if len(history_paths) >= 2:
+        prior_scores = pd.read_parquet(history_paths[-2])
+        prior_scores = prior_scores[prior_scores["ticker"].isin(tickers)].set_index("ticker")
+
+    composite_history = []
+    for path in history_paths:
+        stem = path.stem
+        try:
+            date_part = stem.split("_")[-1]
+            snap_date = datetime.strptime(date_part, "%Y-%m-%d")
+        except ValueError:
+            continue
+        df = pd.read_parquet(path)
+        df = df[df["ticker"].isin(tickers)]
+        if df.empty:
+            continue
+        df = df.set_index("ticker")
+        composite = df["Composite"].reindex(weights.index).fillna(0.0)
+        composite_history.append({
+            "date": snap_date.strftime("%Y-%m-%d"),
+            "value": float((composite * weights).sum()),
+        })
+
+    latest_portfolio_composite = np.nan
+    if not scores.empty and not weights.empty:
+        latest_comp = scores.set_index("ticker")["Composite"].reindex(weights.index).fillna(0.0)
+        latest_portfolio_composite = float((latest_comp * weights).sum())
+
+    price_history = []
+    portfolio_drawdown = np.nan
+    portfolio_return = np.nan
+    if not prices.empty:
+        prices["date"] = pd.to_datetime(prices["date"])
+        wide = prices.pivot_table(index="date", columns="ticker", values="adj_close").sort_index()
+        wide = wide.ffill().dropna(how="all")
+        if not wide.empty:
+            aligned_weights = weights.reindex(wide.columns).fillna(0.0)
+            if aligned_weights.sum() <= 0:
+                aligned_weights[:] = 1.0 / len(aligned_weights)
+            returns = wide.pct_change().fillna(0)
+            portfolio_returns = returns.mul(aligned_weights, axis=1).sum(axis=1)
+            portfolio_index = (1 + portfolio_returns).cumprod()
+            price_history = [
+                {"date": idx.strftime("%Y-%m-%d"), "value": float(val)}
+                for idx, val in portfolio_index.items()
+            ]
+            if not portfolio_index.empty:
+                start_of_year = portfolio_index[portfolio_index.index >= pd.Timestamp(datetime.utcnow().year, 1, 1)]
+                if not start_of_year.empty:
+                    base = start_of_year.iloc[0]
+                    if base != 0:
+                        portfolio_return = float(start_of_year.iloc[-1] / base - 1.0)
+                if portfolio_return != portfolio_return:
+                    portfolio_return = float(portfolio_index.iloc[-1] - 1.0)
+                peak = portfolio_index.cummax()
+                drawdown = portfolio_index / peak - 1.0
+                if not drawdown.empty:
+                    portfolio_drawdown = float(drawdown.iloc[-1])
+
+    watch_rows = []
+    for t in tickers:
+        row = last_scores.loc[t] if t in last_scores.index else None
+        prev = prior_scores.loc[t] if not prior_scores.empty and t in prior_scores.index else None
+        fund = (
+            last_fundamental[last_fundamental["ticker"] == t].iloc[0]
+            if not last_fundamental.empty and t in last_fundamental["ticker"].values
+            else None
+        )
+        filing_url = None
+        filed = None
+        if fund is not None:
+            filed = fund.get("filed") or fund.get("fiscal_end")
+            cik = str(fund.get("cik") or "").zfill(10) if fund.get("cik") else ""
+            if cik:
+                filing_url = f"https://www.sec.gov/edgar/browse/?CIK={cik}&owner=exclude"
+        if row is not None and filed is None:
+            filed = row.get("filed")
+        composite_delta = None
+        if row is not None and prev is not None:
+            composite_delta = float(row.get("Composite", np.nan) - prev.get("Composite", np.nan))
+        watch_rows.append({
+            "ticker": t,
+            "note": notes.get(t, ""),
+            "price": None if row is None else float(row.get("Price", np.nan)),
+            "composite": None if row is None else float(row.get("Composite", np.nan)),
+            "value_z": None if row is None else float(row.get("ValueZ", np.nan)),
+            "quality_z": None if row is None else float(row.get("QualityZ", np.nan)),
+            "momentum": None if row is None else float(row.get("MomScore", np.nan)),
+            "piotroski": None if row is None else float(row.get("PiotroskiF", np.nan)),
+            "volatility": None if row is None else float(row.get("Volatility30d", np.nan)),
+            "sharpe": None if row is None else float(row.get("Sharpe1y", np.nan)),
+            "industry": None if row is None else row.get("industry"),
+            "filed": filed.strftime("%Y-%m-%d") if isinstance(filed, pd.Timestamp) else filed,
+            "filing_url": filing_url,
+            "composite_delta": composite_delta,
+            "weight": float(weights.get(t, 0.0)),
+        })
+
+    warnings = []
+    if not prices.empty:
+        latest_price_date = pd.to_datetime(prices["date"]).max()
+        if latest_price_date is not None:
+            lag_days = (pd.Timestamp.utcnow().normalize() - latest_price_date.normalize()).days
+            if lag_days > 3:
+                warnings.append(f"Prices are {lag_days} days old.")
+    if not fundamentals.empty:
+        latest_fund_date = pd.to_datetime(fundamentals["fiscal_end"]).max()
+        if latest_fund_date is not None:
+            lag_quarters = (pd.Timestamp.utcnow().normalize() - latest_fund_date.normalize()).days / 90
+            if lag_quarters > 2:
+                warnings.append("Fundamentals stale (>2 quarters).")
+    if not watch_rows:
+        warnings.append("No tickers available in latest scores snapshot.")
 
     env = Environment(
         loader=FileSystemLoader(str(ROOT / "templates")),
-        autoescape=select_autoescape()
+        autoescape=select_autoescape(),
     )
     tpl = env.get_template("report.html.j2")
     html = tpl.render(
         generated_at=datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"),
-        top10=top10.to_dict(orient="records")
+        watch_rows=watch_rows,
+        composite_history=composite_history,
+        price_history=price_history,
+        portfolio_return=portfolio_return,
+        portfolio_drawdown=portfolio_drawdown,
+        warnings=warnings,
+        latest_portfolio_composite=latest_portfolio_composite,
     )
 
     reports = ROOT / "reports"
     reports.mkdir(parents=True, exist_ok=True)
     (reports / "latest.html").write_text(html, encoding="utf-8")
 
-    # monthly snapshot
     ym = datetime.utcnow().strftime("%Y-%m")
     (reports / f"{ym}").mkdir(parents=True, exist_ok=True)
     (reports / f"{ym}/index.html").write_text(html, encoding="utf-8")

--- a/src/compute_factors.py
+++ b/src/compute_factors.py
@@ -1,64 +1,247 @@
-import duckdb, pandas as pd, numpy as np
-from src.utils_io import db_conn, PARQ, today_str
-from src.utils_stats import zscore, winsorize
+import pathlib
+import sys
+
+import duckdb
+import numpy as np
+import pandas as pd
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src import industry_map
+from src.utils_io import (
+    PARQ,
+    ROOT,
+    db_conn,
+    load_yaml,
+    register_temp_view,
+    today_str,
+    unregister_temp_view,
+)
+from src.utils_stats import (
+    calc_ev_to_ebitda,
+    calc_fcf_yield,
+    calc_roic,
+    industry_zscores,
+    pct_change_n,
+    piotroski_f_score,
+    winsorize,
+    zscore,
+)
+
+
+def _map_industry(sic: str) -> str:
+    code = str(sic or "").strip()
+    if not code:
+        return industry_map.DEFAULT
+    if code in industry_map.SIC_TO_INDUSTRY:
+        return industry_map.SIC_TO_INDUSTRY[code]
+    if len(code) >= 3 and code[:3] in industry_map.SIC_TO_INDUSTRY:
+        return industry_map.SIC_TO_INDUSTRY[code[:3]]
+    if len(code) >= 2 and code[:2] in industry_map.SIC_TO_INDUSTRY:
+        return industry_map.SIC_TO_INDUSTRY[code[:2]]
+    return industry_map.DEFAULT
+
+
+def _build_ttm_rollup(group: pd.DataFrame) -> pd.DataFrame:
+    g = group.sort_values("fiscal_end").copy()
+    res = pd.DataFrame({"fiscal_end": g["fiscal_end"].values})
+    rolling_cols = {
+        "RevenueTTM": "Revenue",
+        "NetIncomeTTM": "NetIncome",
+        "OpCFTTM": "OperatingCF",
+        "CapexTTM": "CapitalExpenditures",
+        "GrossProfitTTM": "GrossProfit",
+        "EBITDATTM": "EBITDA",
+        "InterestExpenseTTM": "InterestExpense",
+    }
+    for out_col, src_col in rolling_cols.items():
+        res[out_col] = g[src_col].rolling(4, min_periods=1).sum().values
+
+    res["SharesDilutedTTM"] = g["SharesDiluted"].rolling(4, min_periods=1).mean().values
+    passthrough_cols = [
+        "Debt",
+        "CashAndEquivalents",
+        "TotalAssets",
+        "TotalLiabilities",
+        "CurrentAssets",
+        "CurrentLiabilities",
+        "filed",
+        "sic",
+        "cik",
+        "entity_name",
+    ]
+    for col in passthrough_cols:
+        res[col] = g[col].values
+    res["ticker"] = g["ticker"].values
+    res["FCFTTM"] = res["OpCFTTM"] - res["CapexTTM"].fillna(0)
+    return res
+
 
 def compute(prices: pd.DataFrame, fnds: pd.DataFrame) -> pd.DataFrame:
-    # TTM basics from fundamentals
-    fnds = fnds.sort_values(["ticker","fiscal_end"])
-    # forward-fill quarterly into TTM by group
-    def ttm(series):
-        return series.rolling(4, min_periods=1).sum()
+    if prices.empty or fnds.empty:
+        return pd.DataFrame()
 
-    f = fnds.groupby("ticker", group_keys=False).apply(lambda g: pd.DataFrame({
-        "fiscal_end": g["fiscal_end"],
-        "RevenueTTM": ttm(g["Revenue"]),
-        "NetIncomeTTM": ttm(g["NetIncome"]),
-        "OpCFTTM": ttm(g["OperatingCF"]),
-        "CapexTTM": ttm(g["CapitalExpenditures"]),
-        "SharesDilutedTTM": g["SharesDiluted"].rolling(4, min_periods=1).mean(),
-        "Debt": g["Debt"],
-        "Cash": g["CashAndEquivalents"],
-        "Assets": g["TotalAssets"],
-        "Liabilities": g["TotalLiabilities"],
-        "ticker": g["ticker"].values
-    }))
-    f["FCFTTM"] = f["OpCFTTM"] - (f["CapexTTM"].fillna(0))
+    prices = prices.copy()
+    prices["date"] = pd.to_datetime(prices["date"])
+    prices = prices.sort_values(["ticker", "date"])
+    fnds = fnds.copy()
+    fnds["fiscal_end"] = pd.to_datetime(fnds["fiscal_end"])
+    fnds = fnds.sort_values(["ticker", "fiscal_end"])
 
-    # last close per ticker
-    p_last = prices.sort_values("date").groupby("ticker").tail(1)[["ticker","adj_close"]].rename(columns={"adj_close":"Price"})
-    out = f.groupby("ticker").tail(1).merge(p_last, on="ticker", how="left")
+    rollup = (
+        fnds.groupby("ticker", group_keys=False)
+        .apply(_build_ttm_rollup)
+        .reset_index(drop=True)
+    )
 
-    # simple ratios (guard against /0)
-    out["EPS_TTM"] = out["NetIncomeTTM"] / out["SharesDilutedTTM"]
-    out["PE_TTM"] = out["Price"] / out["EPS_TTM"].replace({0:np.nan})
-    out["FCFYield_TTM"] = out["FCFTTM"] / (out["Price"] * out["SharesDilutedTTM"])
+    piotroski_series = []
+    for ticker, grp in rollup.groupby("ticker"):
+        scores = piotroski_f_score(grp)
+        piotroski_series.append(pd.Series(scores.values, index=grp.index))
+    if piotroski_series:
+        rollup["PiotroskiF"] = pd.concat(piotroski_series).sort_index()
+    else:
+        rollup["PiotroskiF"] = np.nan
 
-    # z-scores for Value (lower PE better; higher FCF yield better)
-    out["val_pe"] = -zscore(winsorize(np.log(out["PE_TTM"])))
-    out["val_fcf"] = zscore(winsorize(out["FCFYield_TTM"]))
-    out["ValueScore"] = out[["val_pe","val_fcf"]].mean(axis=1, skipna=True)
+    latest = rollup.groupby("ticker").tail(1).copy()
 
-    # Quality (gross/ROIC proxies minimal — keep simple with FCF/Assets and low leverage)
-    out["Leverage"] = (out["Debt"] - out["Cash"]) / out["Assets"]
-    out["Qual_ROA"] = out["NetIncomeTTM"] / out["Assets"]
-    out["QualScore"] = zscore(winsorize(out["Qual_ROA"])) + (-zscore(winsorize(out["Leverage"])))
-    out["QualScore"] = out["QualScore"] / 2.0
+    last_price = (
+        prices.groupby("ticker").tail(1)[["ticker", "adj_close"]].rename(columns={"adj_close": "Price"})
+    )
+    latest = latest.merge(last_price, on="ticker", how="left")
 
-    # Momentum from prices (6m, 12m)
-    pr = prices.sort_values("date")
-    six = pr.groupby("ticker").apply(lambda g: g.tail(1)["adj_close"].iloc[0] / g.tail(126)["adj_close"].iloc[0] - 1 if len(g)>=127 else np.nan)
-    twelve = pr.groupby("ticker").apply(lambda g: g.tail(1)["adj_close"].iloc[0] / g.tail(252)["adj_close"].iloc[0] - 1 if len(g)>=253 else np.nan)
-    mom = pd.DataFrame({"ticker":six.index, "Mom6m":six.values, "Mom12m":twelve.values})
-    out = out.merge(mom, on="ticker", how="left")
-    out["MomScore"] = zscore(winsorize(out["Mom6m"].fillna(0.0))) * 0.5 + zscore(winsorize(out["Mom12m"].fillna(0.0))) * 0.5
+    latest["EPS_TTM"] = latest["NetIncomeTTM"] / latest["SharesDilutedTTM"].replace({0: np.nan})
+    latest["PE_TTM"] = latest["Price"] / latest["EPS_TTM"].replace({0: np.nan})
+    latest["FCFYield_TTM"] = calc_fcf_yield(
+        latest["FCFTTM"], latest["Price"], latest["SharesDilutedTTM"]
+    )
+    latest["EVToEBITDA"] = calc_ev_to_ebitda(
+        latest["Price"],
+        latest["SharesDilutedTTM"],
+        latest["Debt"],
+        latest["CashAndEquivalents"],
+        latest["EBITDATTM"],
+    )
+    latest["ROIC"] = calc_roic(
+        latest["NetIncomeTTM"],
+        latest["InterestExpenseTTM"],
+        latest["TotalAssets"],
+        latest["CurrentLiabilities"],
+        latest["CashAndEquivalents"],
+        latest["Debt"],
+    )
+    latest["Leverage"] = (
+        (latest["Debt"].fillna(0) - latest["CashAndEquivalents"].fillna(0))
+        / latest["TotalAssets"].replace({0: np.nan})
+    )
+    latest["Qual_ROA"] = latest["NetIncomeTTM"] / latest["TotalAssets"].replace({0: np.nan})
 
-    # Composite
-    out["Composite"] = 0.4*out["ValueScore"] + 0.4*out["QualScore"] + 0.2*out["MomScore"]
+    mom6 = prices.groupby("ticker").apply(lambda g: pct_change_n(g["adj_close"], 126))
+    mom12 = prices.groupby("ticker").apply(lambda g: pct_change_n(g["adj_close"], 252))
+    momentum = pd.DataFrame({"ticker": mom6.index, "Mom6m": mom6.values, "Mom12m": mom12.values})
+    latest = latest.merge(momentum, on="ticker", how="left")
 
-    # select columns
-    cols = ["ticker","Price","PE_TTM","FCFYield_TTM","Qual_ROA","Leverage","Mom6m","Mom12m",
-            "ValueScore","QualScore","MomScore","Composite"]
-    return out[cols].sort_values("Composite", ascending=False)
+    returns = prices.copy()
+    returns["ret"] = returns.groupby("ticker")["adj_close"].pct_change()
+
+    def vol_30(series: pd.Series) -> float:
+        tail = series.dropna().tail(30)
+        if len(tail) < 20:
+            return np.nan
+        return tail.std(ddof=0) * np.sqrt(252)
+
+    def sharpe_1y(series: pd.Series) -> float:
+        tail = series.dropna().tail(252)
+        if len(tail) < 200:
+            return np.nan
+        std = tail.std(ddof=0)
+        if std == 0 or np.isnan(std):
+            return np.nan
+        return np.sqrt(252) * tail.mean() / std
+
+    vol = returns.groupby("ticker")["ret"].apply(vol_30)
+    sharpe = returns.groupby("ticker")["ret"].apply(sharpe_1y)
+    risk = pd.DataFrame({
+        "ticker": vol.index,
+        "Volatility30d": vol.values,
+        "Sharpe1y": sharpe.values,
+    })
+    latest = latest.merge(risk, on="ticker", how="left")
+
+    pe_positive = latest["PE_TTM"].where(latest["PE_TTM"] > 0)
+    latest["Value_PE"] = -zscore(winsorize(np.log(pe_positive)))
+    latest["Value_FCF"] = zscore(winsorize(latest["FCFYield_TTM"]))
+    evebitda_positive = latest["EVToEBITDA"].where(latest["EVToEBITDA"] > 0)
+    latest["Value_EVEBITDA"] = -zscore(winsorize(np.log(evebitda_positive)))
+    latest["ValueScore_raw"] = latest[["Value_PE", "Value_FCF", "Value_EVEBITDA"]].mean(axis=1, skipna=True)
+
+    latest["Quality_ROIC"] = zscore(winsorize(latest["ROIC"]))
+    latest["Quality_Pio"] = zscore(winsorize(latest["PiotroskiF"]))
+    latest["QualityScore_raw"] = latest[["Quality_ROIC", "Quality_Pio"]].mean(axis=1, skipna=True)
+
+    latest["Mom6m_z"] = zscore(winsorize(latest["Mom6m"]))
+    latest["Mom12m_z"] = zscore(winsorize(latest["Mom12m"]))
+    latest["MomScore"] = latest[["Mom6m_z", "Mom12m_z"]].mean(axis=1, skipna=True)
+
+    latest["industry"] = latest["sic"].apply(_map_industry)
+    latest["ValueScore"] = industry_zscores(latest["ValueScore_raw"], latest["industry"])
+    latest["QualityScore"] = industry_zscores(latest["QualityScore_raw"], latest["industry"])
+
+    cfg = load_yaml(ROOT / "config.yml") or {}
+    weights_cfg = cfg.get("weights", {})
+    default_weights = {"value": 0.4, "quality": 0.4, "momentum": 0.2}
+    weights = {
+        "value": float(weights_cfg.get("value", default_weights["value"])),
+        "quality": float(weights_cfg.get("quality", default_weights["quality"])),
+        "momentum": float(weights_cfg.get("momentum", default_weights["momentum"])),
+    }
+    total_weight = sum(weights.values())
+    if total_weight <= 0:
+        weights = default_weights
+        total_weight = 1.0
+    weights = {k: v / total_weight for k, v in weights.items()}
+
+    latest["Composite"] = (
+        weights["value"] * latest["ValueScore"]
+        + weights["quality"] * latest["QualityScore"]
+        + weights["momentum"] * latest["MomScore"]
+    )
+
+    latest["CompositePctile"] = latest["Composite"].rank(pct=True)
+    latest["ValueZ"] = latest["ValueScore"]
+    latest["QualityZ"] = latest["QualityScore"]
+
+    cols = [
+        "ticker",
+        "Price",
+        "PE_TTM",
+        "FCFYield_TTM",
+        "EVToEBITDA",
+        "ROIC",
+        "Leverage",
+        "Qual_ROA",
+        "PiotroskiF",
+        "Mom6m",
+        "Mom12m",
+        "Volatility30d",
+        "Sharpe1y",
+        "ValueScore",
+        "QualityScore",
+        "MomScore",
+        "Composite",
+        "CompositePctile",
+        "ValueZ",
+        "QualityZ",
+        "industry",
+        "sic",
+        "filed",
+        "cik",
+        "entity_name",
+    ]
+
+    return latest[cols].sort_values("Composite", ascending=False)
+
 
 def main():
     con = db_conn()
@@ -66,12 +249,44 @@ def main():
     fnds = con.execute("SELECT * FROM fundamentals_quarterly").df()
     scores = compute(prices, fnds)
     scores.to_parquet(PARQ / f"scores_daily_{today_str()}.parquet", index=False)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS scores_daily AS SELECT * FROM scores
-    """)
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scores_daily (
+            ticker VARCHAR,
+            Price DOUBLE,
+            PE_TTM DOUBLE,
+            FCFYield_TTM DOUBLE,
+            EVToEBITDA DOUBLE,
+            ROIC DOUBLE,
+            Leverage DOUBLE,
+            Qual_ROA DOUBLE,
+            PiotroskiF DOUBLE,
+            Mom6m DOUBLE,
+            Mom12m DOUBLE,
+            Volatility30d DOUBLE,
+            Sharpe1y DOUBLE,
+            ValueScore DOUBLE,
+            QualityScore DOUBLE,
+            MomScore DOUBLE,
+            Composite DOUBLE,
+            CompositePctile DOUBLE,
+            ValueZ DOUBLE,
+            QualityZ DOUBLE,
+            industry VARCHAR,
+            sic VARCHAR,
+            filed TIMESTAMP,
+            cik VARCHAR,
+            entity_name VARCHAR
+        )
+        """
+    )
     con.execute("DELETE FROM scores_daily")
-    con.execute("INSERT INTO scores_daily SELECT * FROM scores", {"scores": scores})
+    view_name = register_temp_view(con, "scores_tmp", scores)
+    if view_name:
+        con.execute(f"INSERT INTO scores_daily SELECT * FROM {view_name}")
+    unregister_temp_view(con, view_name)
     print("Computed scores:", len(scores))
+
 
 if __name__ == "__main__":
     main()

--- a/src/ingest_fundamentals_sec.py
+++ b/src/ingest_fundamentals_sec.py
@@ -1,24 +1,39 @@
-import json, time, pathlib, requests, pandas as pd
-from src.utils_io import ROOT, PARQ, db_conn, load_yaml, today_str
+import pathlib
+import sys
+import time
 
-# Minimal static mapping; extend as needed
-TICKER_TO_CIK = {
-    "MSFT":"0000789019",
-    "AAPL":"0000320193",
-    "AMZN":"0001018724",
-    "GOOGL":"0001652044",
-}
+import pandas as pd
+import requests
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from src.utils_io import (
+    PARQ,
+    ROOT,
+    db_conn,
+    get_ticker_cik_map,
+    load_yaml,
+    register_temp_view,
+    today_str,
+    unregister_temp_view,
+)
 
 FACTS = {
-    "Revenue":"Revenues",                    # may map to "RevenueFromContractWithCustomerExcludingAssessedTax"
-    "NetIncome":"NetIncomeLoss",
-    "SharesDiluted":"WeightedAverageNumberOfDilutedSharesOutstanding",
-    "OperatingCF":"NetCashProvidedByUsedInOperatingActivities",
-    "CapitalExpenditures":"PaymentsToAcquirePropertyPlantAndEquipment",
-    "TotalAssets":"Assets",
-    "TotalLiabilities":"Liabilities",
-    "CashAndEquivalents":"CashAndCashEquivalentsAtCarryingValue",
-    "Debt":"LongTermDebtNoncurrent",
+    "Revenue": "Revenues",
+    "NetIncome": "NetIncomeLoss",
+    "SharesDiluted": "WeightedAverageNumberOfDilutedSharesOutstanding",
+    "OperatingCF": "NetCashProvidedByUsedInOperatingActivities",
+    "CapitalExpenditures": "PaymentsToAcquirePropertyPlantAndEquipment",
+    "TotalAssets": "Assets",
+    "TotalLiabilities": "Liabilities",
+    "CashAndEquivalents": "CashAndCashEquivalentsAtCarryingValue",
+    "Debt": "LongTermDebtNoncurrent",
+    "GrossProfit": "GrossProfit",
+    "CurrentAssets": "AssetsCurrent",
+    "CurrentLiabilities": "LiabilitiesCurrent",
+    "EBITDA": "EarningsBeforeInterestTaxesDepreciationAmortization",
+    "InterestExpense": "InterestExpense",
 }
 
 UA = {"User-Agent": "personal-investor-assistant (contact: example@example.com)"}
@@ -52,7 +67,10 @@ def extract_quarterly(facts: dict, ticker: str) -> pd.DataFrame:
         for v in out:
             end = v.get("end") or v.get("fy")  # end is ISO date
             if not end: continue
-            periods.setdefault(end, {})[name]=v.get("val")
+            entry = periods.setdefault(end, {})
+            entry[name]=v.get("val")
+            if "filed" in v:
+                entry.setdefault("filed", v.get("filed"))
 
     df = pd.DataFrame([
         {"fiscal_end": k, **vals} for k, vals in periods.items()
@@ -60,24 +78,34 @@ def extract_quarterly(facts: dict, ticker: str) -> pd.DataFrame:
     if not df.empty:
         df["ticker"]=ticker
         df["fiscal_end"]=pd.to_datetime(df["fiscal_end"])
+        if "filed" in df.columns:
+            df["filed"] = pd.to_datetime(df["filed"], errors="coerce")
+        entity = facts.get("entity", {})
+        df["cik"] = entity.get("cik")
+        df["sic"] = str(entity.get("sic") or "")
+        df["entity_name"] = entity.get("name")
         df = df.sort_values("fiscal_end")
     return df
 
 def main():
     cfg = load_yaml(ROOT / "watchlist.yml")
     tickers = cfg["tickers"]
+    overrides = {k.upper(): v for k, v in cfg.get("cik_overrides", {}).items()}
+    cik_map = get_ticker_cik_map()
     frames=[]
     for t in tickers:
-        cik = TICKER_TO_CIK.get(t)
+        cik = overrides.get(t.upper()) or cik_map.get(t.upper())
         if not cik:
+            print(f"[WARN] Missing CIK for {t}; skipping.")
             continue
         facts = pull_company_facts(cik)
         df = extract_quarterly(facts, t)
         if not df.empty:
+            df["cik"] = df["cik"].fillna(cik)
             frames.append(df)
 
     fundamentals = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame(
-        columns=["fiscal_end","ticker", *FACTS.keys()]
+        columns=["fiscal_end","ticker", *FACTS.keys(), "filed", "cik", "sic", "entity_name"]
     )
 
     con = db_conn()
@@ -86,13 +114,24 @@ def main():
             fiscal_end DATE, ticker VARCHAR,
             Revenue DOUBLE, NetIncome DOUBLE, SharesDiluted DOUBLE,
             OperatingCF DOUBLE, CapitalExpenditures DOUBLE, TotalAssets DOUBLE,
-            TotalLiabilities DOUBLE, CashAndEquivalents DOUBLE, Debt DOUBLE
+            TotalLiabilities DOUBLE, CashAndEquivalents DOUBLE, Debt DOUBLE,
+            GrossProfit DOUBLE, CurrentAssets DOUBLE, CurrentLiabilities DOUBLE,
+            EBITDA DOUBLE, InterestExpense DOUBLE,
+            filed TIMESTAMP, cik VARCHAR, sic VARCHAR, entity_name VARCHAR
         )
     """)
     # upsert by ticker+fiscal_end (simple replace approach)
-    con.execute("DELETE FROM fundamentals_quarterly WHERE ticker IN ({})".format(
-        ",".join(["?"]*len(tickers))), tickers)
-    con.execute("INSERT INTO fundamentals_quarterly SELECT * FROM df", {"df": fundamentals})
+    if tickers:
+        con.execute(
+            "DELETE FROM fundamentals_quarterly WHERE ticker IN ({})".format(
+                ",".join(["?"] * len(tickers))
+            ),
+            tickers,
+        )
+    view_name = register_temp_view(con, "fundamentals_tmp", fundamentals)
+    if view_name:
+        con.execute(f"INSERT INTO fundamentals_quarterly SELECT * FROM {view_name}")
+    unregister_temp_view(con, view_name)
 
     from src.utils_io import write_parquet
     write_parquet(fundamentals, PARQ / f"fundamentals_quarterly_{today_str()}.parquet")

--- a/src/utils_io.py
+++ b/src/utils_io.py
@@ -1,14 +1,20 @@
-import json, os, sys, time, pathlib
-from typing import Any, Dict, Iterable
+import json
+import pathlib
+import time
 from datetime import datetime
+from typing import Any, Dict, Iterable, Optional
+
 import duckdb
 import pandas as pd
+import requests
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 PARQ = DATA / "parquet"
 DB_PATH = DATA / "db.duckdb"
+SEC_CACHE = DATA / "sec"
 PARQ.mkdir(parents=True, exist_ok=True)
+SEC_CACHE.mkdir(parents=True, exist_ok=True)
 
 def db_conn():
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -32,3 +38,53 @@ def safe_to_numeric(df: pd.DataFrame, cols: Iterable[str]) -> pd.DataFrame:
         if c in df.columns:
             df[c] = pd.to_numeric(df[c], errors="coerce")
     return df
+
+
+def fetch_sec_file(url: str, cache_name: str, max_age_hours: int = 24) -> pathlib.Path:
+    """Download a lightweight SEC reference file with simple caching."""
+    cache_path = SEC_CACHE / cache_name
+    if cache_path.exists():
+        age_hours = (time.time() - cache_path.stat().st_mtime) / 3600
+        if age_hours < max_age_hours:
+            return cache_path
+
+    headers = {
+        "User-Agent": "personal-investor-assistant (contact: example@example.com)",
+    }
+    resp = requests.get(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+    cache_path.write_bytes(resp.content)
+    return cache_path
+
+
+def get_ticker_cik_map(force_refresh: bool = False) -> Dict[str, str]:
+    """Return an uppercase ticker -> zero-padded CIK mapping from the SEC file."""
+    cache_file = "company_tickers.json"
+    if force_refresh:
+        cache_path = fetch_sec_file(
+            "https://www.sec.gov/files/company_tickers.json", cache_file, max_age_hours=0
+        )
+    else:
+        cache_path = fetch_sec_file(
+            "https://www.sec.gov/files/company_tickers.json", cache_file
+        )
+
+    data = json.loads(cache_path.read_text(encoding="utf-8"))
+    mapping = {
+        entry["ticker"].upper(): str(entry["cik_str"]).zfill(10)
+        for entry in data.values()
+    }
+    return mapping
+
+
+def register_temp_view(con: duckdb.DuckDBPyConnection, name: str, df: pd.DataFrame) -> Optional[str]:
+    """Register a pandas DataFrame as a DuckDB view if it has rows."""
+    if df is None or df.empty:
+        return None
+    con.register(name, df)
+    return name
+
+
+def unregister_temp_view(con: duckdb.DuckDBPyConnection, name: Optional[str]) -> None:
+    if name:
+        con.unregister(name)

--- a/src/utils_stats.py
+++ b/src/utils_stats.py
@@ -1,14 +1,107 @@
 import numpy as np
 import pandas as pd
 
-def zscore(series: pd.Series) -> pd.Series:
-    return (series - series.mean(skipna=True)) / series.std(skipna=True)
 
-def winsorize(series: pd.Series, lower=0.01, upper=0.99) -> pd.Series:
+def zscore(series: pd.Series) -> pd.Series:
+    std = series.std(skipna=True, ddof=0)
+    if std == 0 or np.isnan(std):
+        return pd.Series(np.zeros(len(series)), index=series.index)
+    return (series - series.mean(skipna=True)) / std
+
+
+def winsorize(series: pd.Series, lower: float = 0.01, upper: float = 0.99) -> pd.Series:
+    if series.empty:
+        return series
     lo, hi = series.quantile(lower), series.quantile(upper)
     return series.clip(lower=lo, upper=hi)
 
+
 def pct_change_n(prices: pd.Series, n: int) -> float:
-    if len(prices) < n+1 or prices.iloc[-n-1] == 0:
+    if len(prices) < n + 1 or prices.iloc[-n - 1] == 0:
         return np.nan
-    return prices.iloc[-1] / prices.iloc[-n-1] - 1.0
+    return prices.iloc[-1] / prices.iloc[-n - 1] - 1.0
+
+
+def industry_zscores(values: pd.Series, industries: pd.Series) -> pd.Series:
+    def _zs(x: pd.Series) -> pd.Series:
+        return zscore(x.fillna(x.mean(skipna=True)))
+
+    grouped = values.groupby(industries)
+    return grouped.transform(_zs)
+
+
+def calc_fcf_yield(fcf_ttm: pd.Series, price: pd.Series, shares: pd.Series) -> pd.Series:
+    denominator = price * shares
+    denominator = denominator.replace({0: np.nan})
+    return fcf_ttm / denominator
+
+
+def calc_ev_to_ebitda(
+    price: pd.Series,
+    shares: pd.Series,
+    debt: pd.Series,
+    cash: pd.Series,
+    ebitda_ttm: pd.Series,
+) -> pd.Series:
+    enterprise_value = price * shares + debt.fillna(0) - cash.fillna(0)
+    return enterprise_value / ebitda_ttm.replace({0: np.nan})
+
+
+def calc_roic(
+    net_income_ttm: pd.Series,
+    interest_expense_ttm: pd.Series,
+    total_assets: pd.Series,
+    current_liabilities: pd.Series,
+    cash: pd.Series,
+    debt: pd.Series,
+) -> pd.Series:
+    invested_capital = (
+        total_assets.fillna(0)
+        - current_liabilities.fillna(0)
+        - cash.fillna(0)
+        + debt.fillna(0)
+    )
+    invested_capital = invested_capital.replace({0: np.nan})
+    nopat = net_income_ttm.fillna(0) + interest_expense_ttm.fillna(0)
+    return nopat / invested_capital
+
+
+def piotroski_f_score(df: pd.DataFrame) -> pd.Series:
+    required = [
+        "fiscal_end",
+        "NetIncomeTTM",
+        "OpCFTTM",
+        "TotalAssets",
+        "Debt",
+        "CurrentAssets",
+        "CurrentLiabilities",
+        "GrossProfitTTM",
+        "RevenueTTM",
+        "SharesDilutedTTM",
+    ]
+    for col in required:
+        if col not in df.columns:
+            raise KeyError(f"Missing column '{col}' for Piotroski F-score computation")
+
+    df = df.sort_values("fiscal_end")
+    roa = df["NetIncomeTTM"] / df["TotalAssets"].replace({0: np.nan})
+    cfo = df["OpCFTTM"] / df["TotalAssets"].replace({0: np.nan})
+    accrual = df["OpCFTTM"] - df["NetIncomeTTM"]
+    leverage = df["Debt"] / df["TotalAssets"].replace({0: np.nan})
+    current_ratio = df["CurrentAssets"] / df["CurrentLiabilities"].replace({0: np.nan})
+    gross_margin = df["GrossProfitTTM"] / df["RevenueTTM"].replace({0: np.nan})
+    asset_turnover = df["RevenueTTM"] / df["TotalAssets"].replace({0: np.nan})
+    shares = df["SharesDilutedTTM"]
+
+    components = pd.DataFrame(index=df.index)
+    components["roa_pos"] = (roa > 0).astype(int)
+    components["cfo_pos"] = (df["OpCFTTM"] > 0).astype(int)
+    components["delta_roa"] = (roa > roa.shift(1)).astype(int)
+    components["accrual"] = (accrual > 0).astype(int)
+    components["delta_leverage"] = (leverage < leverage.shift(1)).astype(int)
+    components["delta_liquidity"] = (current_ratio > current_ratio.shift(1)).astype(int)
+    components["margin"] = (gross_margin > gross_margin.shift(1)).astype(int)
+    components["turnover"] = (asset_turnover > asset_turnover.shift(1)).astype(int)
+    components["shares"] = (shares <= shares.shift(1)).astype(int)
+
+    return components.fillna(0).sum(axis=1)

--- a/templates/report.html.j2
+++ b/templates/report.html.j2
@@ -14,31 +14,122 @@
   </style>
 </head>
 <body>
-  <h1>Daily Screen — Top Ideas</h1>
+  <h1>Personal Investor Assistant — Watchlist Pulse</h1>
   <div class="sub">Generated: {{ generated_at }}</div>
-  <table>
-    <thead>
-      <tr>
-        <th>Ticker</th><th>Price</th><th>P/E (TTM)</th><th>FCF Yield</th>
-        <th>ROA</th><th>Leverage</th><th>Mom6m</th><th>Mom12m</th><th>Composite</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for r in top10 %}
-      <tr>
-        <td><span class="chip">{{ r["ticker"] }}</span></td>
-        <td>{{ "%.2f"|format(r["Price"] or 0) }}</td>
-        <td>{{ "%.1f"|format(r["PE_TTM"] or 0) }}</td>
-        <td>{{ "%.2f"|format(r["FCFYield_TTM"] or 0) }}</td>
-        <td>{{ "%.3f"|format(r["Qual_ROA"] or 0) }}</td>
-        <td>{{ "%.3f"|format(r["Leverage"] or 0) }}</td>
-        <td>{{ "%.2f"|format(r["Mom6m"] or 0) }}</td>
-        <td>{{ "%.2f"|format(r["Mom12m"] or 0) }}</td>
-        <td><b>{{ "%.3f"|format(r["Composite"] or 0) }}</b></td>
-      </tr>
+
+  {% if warnings %}
+  <div style="background:#fff4e5; border:1px solid #f5c97a; padding:12px 16px; margin-bottom:16px; border-radius:6px; color:#7a4b00;">
+    <strong>Warnings:</strong>
+    <ul style="margin:8px 0 0 18px; padding:0;">
+      {% for w in warnings %}
+      <li>{{ w }}</li>
       {% endfor %}
-    </tbody>
-  </table>
-  <p style="color:#888; margin-top:24px;">For personal research only. Not investment advice.</p>
+    </ul>
+  </div>
+  {% endif %}
+
+  <section style="margin-bottom:28px;">
+    <h2 style="margin-bottom:6px;">Portfolio Overview</h2>
+    <div style="display:flex; flex-wrap:wrap; gap:16px;">
+      <div style="flex:1 1 180px; background:#f6f8fa; padding:12px 16px; border-radius:8px;">
+        <div style="font-size:12px; text-transform:uppercase; color:#57606a;">Latest Composite</div>
+        <div style="font-size:24px; font-weight:600;">{% if latest_portfolio_composite is not none and latest_portfolio_composite == latest_portfolio_composite %}{{ "%.3f"|format(latest_portfolio_composite) }}{% else %}--{% endif %}</div>
+      </div>
+      <div style="flex:1 1 180px; background:#f6f8fa; padding:12px 16px; border-radius:8px;">
+        <div style="font-size:12px; text-transform:uppercase; color:#57606a;">YTD Return (Eq-weight)</div>
+        <div style="font-size:24px; font-weight:600;">{% if portfolio_return is not none and portfolio_return == portfolio_return %}{{ "%.1f%%"|format(portfolio_return * 100) }}{% else %}--{% endif %}</div>
+      </div>
+      <div style="flex:1 1 180px; background:#f6f8fa; padding:12px 16px; border-radius:8px;">
+        <div style="font-size:12px; text-transform:uppercase; color:#57606a;">Latest Drawdown</div>
+        <div style="font-size:24px; font-weight:600;">{% if portfolio_drawdown is not none and portfolio_drawdown == portfolio_drawdown %}{{ "%.1f%%"|format(portfolio_drawdown * 100) }}{% else %}--{% endif %}</div>
+      </div>
+    </div>
+    <div style="margin-top:16px;">
+      <h3 style="margin-bottom:6px;">Composite History</h3>
+      {% if composite_history %}
+      <table>
+        <thead><tr><th>Date</th><th>Weighted Composite</th></tr></thead>
+        <tbody>
+          {% for entry in composite_history[-10:] %}
+          <tr>
+            <td style="text-align:left;">{{ entry.date }}</td>
+            <td>{{ "%.3f"|format(entry.value) }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p style="color:#6e7781;">No composite history captured yet.</p>
+      {% endif %}
+    </div>
+    <div style="margin-top:16px;">
+      <h3 style="margin-bottom:6px;">Portfolio Index (Eq-weight)</h3>
+      {% if price_history %}
+      <table>
+        <thead><tr><th>Date</th><th>Index</th></tr></thead>
+        <tbody>
+          {% for entry in price_history[-10:] %}
+          <tr>
+            <td style="text-align:left;">{{ entry.date }}</td>
+            <td>{{ "%.3f"|format(entry.value) }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p style="color:#6e7781;">Insufficient price history to compute portfolio index.</p>
+      {% endif %}
+    </div>
+  </section>
+
+  <section>
+    <h2 style="margin-bottom:6px;">Watchlist Detail</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Ticker</th>
+          <th>Note</th>
+          <th>Price</th>
+          <th>Composite</th>
+          <th>Δ Composite (d)</th>
+          <th>Value Z</th>
+          <th>Quality Z</th>
+          <th>Momentum</th>
+          <th>Piotroski F</th>
+          <th>Vol(30d)</th>
+          <th>Sharpe(1y)</th>
+          <th>Industry</th>
+          <th>Last Filing</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in watch_rows %}
+        <tr>
+          <td><span class="chip">{{ r.ticker }}</span></td>
+          <td style="text-align:left; max-width:220px;">{{ r.note }}</td>
+          <td>{% if r.price is not none %}{{ "%.2f"|format(r.price) }}{% else %}--{% endif %}</td>
+          <td>{% if r.composite is not none %}{{ "%.3f"|format(r.composite) }}{% else %}--{% endif %}</td>
+          <td>{% if r.composite_delta is not none %}{{ "%.3f"|format(r.composite_delta) }}{% else %}--{% endif %}</td>
+          <td>{% if r.value_z is not none %}{{ "%.2f"|format(r.value_z) }}{% else %}--{% endif %}</td>
+          <td>{% if r.quality_z is not none %}{{ "%.2f"|format(r.quality_z) }}{% else %}--{% endif %}</td>
+          <td>{% if r.momentum is not none %}{{ "%.2f"|format(r.momentum) }}{% else %}--{% endif %}</td>
+          <td>{% if r.piotroski is not none %}{{ "%.0f"|format(r.piotroski) }}{% else %}--{% endif %}</td>
+          <td>{% if r.volatility is not none %}{{ "%.2f"|format(r.volatility) }}{% else %}--{% endif %}</td>
+          <td>{% if r.sharpe is not none %}{{ "%.2f"|format(r.sharpe) }}{% else %}--{% endif %}</td>
+          <td>{% if r.industry %}{{ r.industry }}{% else %}--{% endif %}</td>
+          <td>
+            {% if r.filing_url %}
+              <a href="{{ r.filing_url }}" target="_blank" rel="noopener">{{ r.filed or "View" }}</a>
+            {% else %}
+              {{ r.filed or "--" }}
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <p style="color:#888; margin-top:24px;">Educational use only. Not investment advice.</p>
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/fixtures/golden_tickers.json
+++ b/tests/fixtures/golden_tickers.json
@@ -1,0 +1,74 @@
+[
+  {
+    "ticker": "MSFT",
+    "price": 330.0,
+    "shares": 7400000000.0,
+    "fcf_ttm": 64000000000.0,
+    "debt": 58000000000.0,
+    "cash": 76000000000.0,
+    "ebitda_ttm": 97000000000.0,
+    "net_income_ttm": 72000000000.0,
+    "interest_expense_ttm": 2200000000.0,
+    "total_assets": 411000000000.0,
+    "current_liabilities": 90000000000.0,
+    "expected": {
+      "fcf_yield": 0.0262080262,
+      "ev_to_ebitda": 24.989690722,
+      "roic": 0.2448844884
+    }
+  },
+  {
+    "ticker": "AAPL",
+    "price": 190.0,
+    "shares": 15700000000.0,
+    "fcf_ttm": 100000000000.0,
+    "debt": 120000000000.0,
+    "cash": 60000000000.0,
+    "ebitda_ttm": 130000000000.0,
+    "net_income_ttm": 100000000000.0,
+    "interest_expense_ttm": 3000000000.0,
+    "total_assets": 352000000000.0,
+    "current_liabilities": 130000000000.0,
+    "expected": {
+      "fcf_yield": 0.0335232987,
+      "ev_to_ebitda": 23.407692308,
+      "roic": 0.365248227
+    }
+  },
+  {
+    "ticker": "JPM",
+    "price": 145.0,
+    "shares": 2900000000.0,
+    "fcf_ttm": 45000000000.0,
+    "debt": 380000000000.0,
+    "cash": 120000000000.0,
+    "ebitda_ttm": 75000000000.0,
+    "net_income_ttm": 45000000000.0,
+    "interest_expense_ttm": 7000000000.0,
+    "total_assets": 3920000000000.0,
+    "current_liabilities": 750000000000.0,
+    "expected": {
+      "fcf_yield": 0.1070154578,
+      "ev_to_ebitda": 9.0733333333,
+      "roic": 0.0151603499
+    }
+  },
+  {
+    "ticker": "XOM",
+    "price": 115.0,
+    "shares": 4100000000.0,
+    "fcf_ttm": 65000000000.0,
+    "debt": 45000000000.0,
+    "cash": 30000000000.0,
+    "ebitda_ttm": 90000000000.0,
+    "net_income_ttm": 55000000000.0,
+    "interest_expense_ttm": 1500000000.0,
+    "total_assets": 369000000000.0,
+    "current_liabilities": 95000000000.0,
+    "expected": {
+      "fcf_yield": 0.1378579003,
+      "ev_to_ebitda": 5.4055555556,
+      "roic": 0.1955017301
+    }
+  }
+]

--- a/tests/test_piotroski.py
+++ b/tests/test_piotroski.py
@@ -1,2 +1,83 @@
-def test_placeholder():
-    assert 1 + 1 == 2
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.utils_stats import (
+    calc_ev_to_ebitda,
+    calc_fcf_yield,
+    calc_roic,
+    industry_zscores,
+    piotroski_f_score,
+    winsorize,
+)
+
+
+def test_piotroski_score_hits_all_components():
+    dates = pd.to_datetime(["2022-12-31", "2023-03-31", "2023-06-30"])  # quarterly
+    df = pd.DataFrame(
+        {
+            "fiscal_end": dates,
+            "NetIncomeTTM": [40, 45, 52],
+            "OpCFTTM": [42, 48, 55],
+            "TotalAssets": [200, 205, 210],
+            "Debt": [80, 78, 75],
+            "CurrentAssets": [60, 65, 72],
+            "CurrentLiabilities": [40, 39, 38],
+            "GrossProfitTTM": [120, 126, 135],
+            "RevenueTTM": [300, 310, 325],
+            "SharesDilutedTTM": [50, 49, 48],
+        }
+    )
+    scores = piotroski_f_score(df)
+    assert int(scores.iloc[-1]) == 9
+    assert int(scores.iloc[0]) == 3
+
+
+def test_financial_ratio_helpers_match_expected_golden_values():
+    fixture_path = Path(__file__).resolve().parent / "fixtures" / "golden_tickers.json"
+    payload = json.loads(fixture_path.read_text())
+    for entry in payload:
+        fcfy = calc_fcf_yield(
+            pd.Series([entry["fcf_ttm"]]),
+            pd.Series([entry["price"]]),
+            pd.Series([entry["shares"]]),
+        ).iloc[0]
+        ev_ebitda = calc_ev_to_ebitda(
+            pd.Series([entry["price"]]),
+            pd.Series([entry["shares"]]),
+            pd.Series([entry["debt"]]),
+            pd.Series([entry["cash"]]),
+            pd.Series([entry["ebitda_ttm"]]),
+        ).iloc[0]
+        roic = calc_roic(
+            pd.Series([entry["net_income_ttm"]]),
+            pd.Series([entry["interest_expense_ttm"]]),
+            pd.Series([entry["total_assets"]]),
+            pd.Series([entry["current_liabilities"]]),
+            pd.Series([entry["cash"]]),
+            pd.Series([entry["debt"]]),
+        ).iloc[0]
+
+        exp = entry["expected"]
+        assert np.isclose(fcfy, exp["fcf_yield"], rtol=1e-3)
+        assert np.isclose(ev_ebitda, exp["ev_to_ebitda"], rtol=1e-3)
+        assert np.isclose(roic, exp["roic"], rtol=1e-3)
+
+
+def test_industry_zscores_handles_single_member_industry():
+    values = pd.Series([1.0, 2.0, 3.0], index=["A", "B", "C"])
+    industries = pd.Series(["Tech", "Tech", "Utilities"], index=["A", "B", "C"])
+    zscores = industry_zscores(values, industries)
+    # Tech should be standardised, Utilities singleton should map to zero
+    assert np.isclose(zscores.loc["C"], 0.0)
+    assert np.isclose(zscores.loc["A"], -1.0)
+    assert np.isclose(zscores.loc["B"], 1.0)
+
+
+def test_winsorize_clips_extremes():
+    series = pd.Series([1, 2, 3, 100])
+    clipped = winsorize(series, lower=0.0, upper=0.75)
+    assert clipped.iloc[-1] == pytest.approx(series.quantile(0.75))


### PR DESCRIPTION
## Summary
- load SEC ticker metadata dynamically, capture richer fundamentals, and register DuckDB writes safely
- expand factor computation with Piotroski F, risk metrics, config-driven weights, and industry-relative z-scores
- enhance the static report with watchlist/portfolio context and add unit tests covering ratio helpers and Piotroski logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc0bbc1ec08326b2c675a4e84a5383