### PR TITLE
Fix YAML step name quoting to satisfy CI

### DIFF
--- a/.github/workflows/nigthly.yml
+++ b/.github/workflows/nigthly.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install deps
         run: pip install -r requirements.txt
 
-      - name: Debug: Print working directory and Python path
+      - name: "Debug: Print working directory and Python path"
         run: |
           echo "PWD: $(pwd)"
           echo "PYTHONPATH: $PYTHONPATH"


### PR DESCRIPTION
## Summary
- quote the debug step name in the nightly workflow so the colon is treated as part of the string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1565ef7083269ca3ab2f40788d85